### PR TITLE
Add AfterCdts to package exports

### DIFF
--- a/packages/wet-boew-react/src/index.ts
+++ b/packages/wet-boew-react/src/index.ts
@@ -10,6 +10,7 @@ export {
   SplashContent,
   SplashTop,
   Top,
+  AfterCdts,
 } from "./cdts";
 export { Language, useLanguage, useLngLinks } from "./language";
 export { Heading, H1, H2, H3, H4, H5, H6, PageTitle } from "./headings";


### PR DESCRIPTION
We have a use case in SAR-DMTS where we'll need to customize the AppTemplate component, and in order to re-create it, we'll need access to the AfterCdts component.